### PR TITLE
CMakeLists.txt: define as C project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5.2)
 
-project(calibrator)
+project(calibrator C)
 
 set(BIN_PATH "bin")
 


### PR DESCRIPTION
Define that this is a C project to avoid raising a build failure if no C++ compiler is found