### PR TITLE
calibrator.c: include <unistd.h>

### DIFF
--- a/calibrator.c
+++ b/calibrator.c
@@ -48,6 +48,7 @@
 #include	<math.h>
 #include	<string.h>
 #include	<stdarg.h>
+#include	<unistd.h>
 
 #define VERSION "fukien-alpha"
 


### PR DESCRIPTION
Include `unistd.h` to avoid the following build failure with gcc >= 14:

```
/home/autobuild/autobuild/instance-4/output-1/build/cache-calibrator/calibrator.c: In function 'runCache': /home/autobuild/autobuild/instance-4/output-1/build/cache-calibrator/calibrator.c:267:24: error: implicit declaration of function 'getpagesize' [-Wimplicit-function-declaration]
  267 |         lng     pgsz = getpagesize();
      |                        ^~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/ce26b55b52428984cb4a2fca7b4ff73944d7a3af